### PR TITLE
Force sqlite3 compilation to use python3

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+python=/usr/bin/python3


### PR DESCRIPTION
With Python 2.7 being officially discontinued back in January, it is recommended to switch over as it can become a security risk due to no more security updates going out.
The dependency sqlite3 that yarn installs requires python for compilation but it tries to call /usr/bin/python instead /usr/bin/python3.
In my case on Ubuntu 20.04, /usr/bin/python did not exist (on some this would symlink to python3)
This file addition will force python3 to be used in place of python which will fix an error of sqlite3 not finding python.