### PR TITLE
Add CloudFlare API token support

### DIFF
--- a/config.sample.js
+++ b/config.sample.js
@@ -501,6 +501,7 @@ module.exports = {
       fill your API key, email and your site's zone ID below, then set "purgeCache" to true.
       This will only purge cache of the deleted file and its associated thumb.
     */
+    apiToken: '',
     apiKey: '',
     email: '',
     zoneId: '',

--- a/controllers/utilsController.js
+++ b/controllers/utilsController.js
@@ -64,7 +64,7 @@ const statsCache = {
   }
 }
 
-const cloudflareAuth = config.cloudflare && config.cloudflare.apiKey &&
+const cloudflareAuth = config.cloudflare && config.cloudflare.apiToken && config.cloudflare.apiKey &&
   config.cloudflare.email && config.cloudflare.zoneId
 
 self.mayGenerateThumb = extname => {
@@ -525,6 +525,7 @@ self.purgeCloudflareCache = async (names, uploads, thumbs) => {
         method: 'POST',
         body: JSON.stringify({ files: chunk }),
         headers: {
+          'Authorization: Bearer': config.cloudflare.apiToken,
           'Content-Type': 'application/json',
           'X-Auth-Email': config.cloudflare.email,
           'X-Auth-Key': config.cloudflare.apiKey


### PR DESCRIPTION
I wanted to add API token support because the current API key system has some serious security risks if the server is compromised as it gives access to change anything from the account.

API tokens were introduced about a year ago and make it so you can create permissions for specific zones. Something like this should work for purging the cache
![image](https://user-images.githubusercontent.com/6313132/85823667-993fab80-b743-11ea-9ac7-7ba371303aa5.png)


Could it be possible to either deprecate the old `apiKey` `email` system or maybe hide them when `apiToken` is used and vice versa?
https://api.cloudflare.com/#getting-started-requests gives an example of the two
```
curl -X GET "https://api.cloudflare.com/client/v4/zones/cd7d0123e3012345da9420df9514dad0" \
     -H "Content-Type:application/json" \
     -H "Authorization: Bearer YQSn-xWAQiiEh9qM58wZNnyQS7FUdoqGIUAbrh7T"
```

```
curl -X GET "https://api.cloudflare.com/client/v4/zones/cd7d0123e3012345da9420df9514dad0" \
     -H "Content-Type:application/json" \
     -H "X-Auth-Key:1234567893feefc5f0q5000bfo0c38d90bbeb" \
     -H "X-Auth-Email:example@example.com"
```