### PR TITLE
change window.location.host to window.location.hostname

### DIFF
--- a/src/js/misc/utils.js
+++ b/src/js/misc/utils.js
@@ -18,7 +18,7 @@ page.prepareShareX = () => {
   headers.age = page.uploadAge || ''
   headers.striptags = page.stripTags || ''
 
-  const origin = (window.location.hostname + window.location.pathname).replace(/\/(dashboard)?$/, '')
+  const origin = (window.location.host + window.location.pathname).replace(/\/(dashboard)?$/, '')
   const originClean = origin.replace(/\//g, '_')
 
   const sharexConfObj = {


### PR DESCRIPTION
location.hostname() is unsupported by Opera and gives an error using the latest ESLint gulp plugin.

The error I see on running `gulp default` is 
```js
Starting 'default'...
Starting 'lint'...
Starting 'lint:js'...
Starting 'lint:css'... 
/lolisafe/src/js/misc/utils.js
  21:19  error  location.hostname() is not supported in Opera 67  compat/compat

✖ 1 problem (1 error, 0 warnings)

[14:47:30] 'lint:js' errored after 8.3 s
[14:47:30] ESLintError in plugin "gulp-eslint"
Message:
    Failed with 1 error
Details:
    domainEmitter: [object Object]
    domainThrown: false
```