### PR TITLE
Add action for automatic lint/building of static resources

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,38 @@
+name: build
+
+on:
+  push:
+    branches:
+      - safe.fiery.me
+    paths:
+      - 'src/js/*.js'
+      - 'src/css/*.scss'
+      - 'src/libs/fontello/*.css'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Get yarn cache directory path
+      id: yarn-cache-dir-path
+      run: echo "::set-output name=dir::$(yarn cache dir)"
+
+    - uses: actions/cache@v2
+      id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+      with:
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
+
+    - name: Install dependencies
+      run: yarn install
+    - name: yarn build
+      run: yarn build
+    - uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        commit_message: gulp build assets
+        commit_user_name: Gulp
+      env:
+        CI: true


### PR DESCRIPTION
This will run the yarn build every time a file is modified in the `/src` folder and push the updated `/dist` files in a new commit.