### PR TITLE
Add deployment action for CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,28 @@
+name: deploy
+
+on:
+  push:
+    branches: [ safe.fiery.me ]
+
+jobs:
+  build:
+    runs-on: self-hosted
+    steps:
+    - uses: actions/checkout@v2
+    - name: Get yarn cache directory path
+      id: yarn-cache-dir-path
+      run: echo "::set-output name=dir::$(yarn cache dir)"
+
+    - uses: actions/cache@v2
+      id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+      with:
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
+    - name: update packages
+      run: yarn --production
+    - name: reload instance
+      run: pm2 reload lolisafe
+      env:
+        CI: true


### PR DESCRIPTION
This can be used if you use a development server and want to automate pushes to live for a main branch. It will require a self-hosted runner for Github actions. This should be safe to run with a self hosted runner on this public repository since it only pulls the main branch when something is pushed to the main branch. Forks should not have access to it even with a pull request being made.

This requires setting up a pm2 alias