### PR TITLE
Improve Dockerfile and create a .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+# git directories
+.git
+.github

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,16 +8,17 @@ WORKDIR /usr/src/lolisafe
 
 COPY package.json yarn.lock ./
 
-RUN apk add --no-cache --virtual build-dependencies python make g++ && apk add --no-cache ffmpeg
+RUN apk --no-cache update \
+&& apk add --no-cache --virtual build-dependencies python make g++ \
+&& apk add --no-cache ffmpeg \
+&& apk del build-dependencies \
+&& yarn install --production \
+&& yarn cache clean
 
 ADD config.sample.js config.js
 
-RUN yarn install
-
-RUN apk update
-
-RUN apk del build-dependencies
-
 COPY . .
+
 EXPOSE 9999
+
 CMD ["node", "lolisafe.js"]


### PR DESCRIPTION
Hi.
The current dockerfile generate a image with size of 718MB because use more layers since have multiples RUN commands.
This new dockerfile aim to reduce layers and size, now it's only 241MB.
This image are now 66% more smaller.

Thank you.